### PR TITLE
Allow creating unsigned release apks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Type: `string`
 
 The password of the key alias.
 
+##### storeType
+
+Type: `string`
+
+The format of the key file. The default is to auto-detect based on the file extension.
+
 ## Related
 
 See [`gulp-cordova`](https://github.com/SamVerschueren/gulp-cordova) for the full list of available packages.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,30 @@ This plugin will build the cordova project for the Android platform.
 Because the plugin returns the apk file, you can pipe it to ```gulp.dest```. This will store the ```android-debug.apk``` file
 in the ```apk``` directory.
 
+### Build a release apk
+
+By setting release to true, the plugin will build a release version of the SDK. This will store the ```android-release-unsigned.apk```
+file in the ```apk``` directory.
+
+```JavaScript
+var gulp = require('gulp'),
+    create = require('gulp-cordova-create'),
+    plugin = require('gulp-cordova-plugin'),
+    android = require('gulp-cordova-build-android');
+
+gulp.task('build', function() {
+    return gulp.src('dist')
+        .pipe(create())
+        .pipe(plugin('org.apache.cordova.dialogs'))
+        .pipe(plugin('org.apache.cordova.camera'))
+        .pipe(android({ release: true }))
+        .pipe(gulp.dest('apk'));
+```
+
 ### Sign the apk
 
-By not passing any options to the plugin, you will receive a debug version of your apk. It's possible to let the plugin
-do the heavy lifting and let it create a signed release version.
+To produce a signed apk you need to pass signing options to the plugin. If you pass signing options to the plugin you do not need to
+specify that it is a release build as the plugin will do a release build automatically
 
 ```JavaScript
 var gulp = require('gulp'),
@@ -58,6 +78,12 @@ store the `android-release.apk` file in the `apk` directory.
 ### android([options])
 
 #### options
+
+##### release
+
+Type: `boolean`
+
+Set the build to be a release build.
 
 ##### storeFile
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ module.exports = function(options) {
                 if(options.keyPassword) {
                     data.push('keyPassword=' + options.keyPassword);
                 }
+                if(options.storeType) {
+                    data.push('storeType=' + options.storeType);
+                }
                 
                 // Write the release-signing.properties file
                 fs.writeFileSync(path.join(androidPath, 'release-signing.properties'), data.join(os.EOL));

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ module.exports = function(options) {
     }, function(cb) {
         var self = this,
             androidPath = path.join(cordovaLib.findProjectRoot(), 'platforms', 'android'),
-            release = options.storeFile && options.keyAlias;
+            sign = options.storeFile && options.keyAlias,
+            release = options.release || sign;
 
         Q.fcall(function() {
             return fs.existsSync(androidPath);
@@ -40,14 +41,19 @@ module.exports = function(options) {
                 return cordova.platforms('add', 'android');
             }
         }).then(function() {
-            if(release) {
+            if(sign) {
                 var data = [];
 
-                // Iterate over all the options and add them to the array that will be written to the properties file
-                for(var key in options) {
-                    data.push(key + '=' + options[key]);
+                // Add all the options related to key signing to the array to be added to 'release-signing.properties'
+                data.push('storeFile=' + options.storeFile);
+                data.push('keyAlias=' + options.keyAlias);
+                if(options.storePassword) {
+                    data.push('storePassword=' + options.storePassword);
                 }
-
+                if(options.keyPassword) {
+                    data.push('keyPassword=' + options.keyPassword);
+                }
+                
                 // Write the release-signing.properties file
                 fs.writeFileSync(path.join(androidPath, 'release-signing.properties'), data.join(os.EOL));
             }
@@ -66,16 +72,19 @@ module.exports = function(options) {
                 cwd = process.env.PWD,
                 contents;
 
-            if(release) {
+            if(sign) {
                 // Define the release variables
                 path = path.join(base, 'android-release.apk');
-                contents = fs.readFileSync(path);
-            }
+            } else if (release) {
+                // Define the unsigned release variables
+                path = path.join(base, 'android-release-unsigned.apk');
+             }
             else {
                 // Define the debug variables
                 path = path.join(base, 'android-debug.apk');
-                contents = fs.readFileSync(path);
             }
+            
+            contents = fs.readFileSync(path);
 
             // Make sure the apk is passed to the next step
             self.push(new gutil.File({


### PR DESCRIPTION
Hi @SamVerschueren,
This adds the same functionality as my other pull request, but with the release flag on the options object.
My one concern with this is that previously users could set the storeType parameter in the release-signing.properties file, even though it wasn't on the API, whereas they can no longer do this. This parameter is valid according to this documentation: https://cordova.apache.org/docs/en/edge/guide_platforms_android_tools.md.html. It might be worth adding this to the API, or just to the code.
