### PR TITLE
Update generation of the build options for recent cordova-lib versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,24 +55,31 @@ module.exports = function (options) {
 				}
 			})
 			.then(() => {
-				const options = [];
+				const buildOptions = {
+					platforms: ['android']
+				};
 
 				if (release) {
 					// If the user wants to build for release, add the option
-					options.push('--release');
+					buildOptions.release = true;
 				}
 
-				if (buildMethod === 'ant') {
-					options.push('--ant');
-				} else {
-					options.push('--gradle');
+				switch (buildMethod) {
+					case 'gradle':
+						buildOptions.gradle = true;
+						break;
+					case 'ant':
+						throw new Error('Build method "ant" is no longer supported');
+					default:
+						// Use whatever cordova-android uses.
+						break;
 				}
 
 				// Build the platform
-				return cordova.build({platforms: ['android'], options});
+				return cordova.build(buildOptions);
 			})
 			.then(() => {
-				const apkOutputPath = buildMethod === 'ant' ? 'bin' : 'build/outputs/apk';
+				const apkOutputPath = 'build/outputs/apk';
 				const base = path.join(androidPath, apkOutputPath);
 				const cwd = process.env.PWD;
 

--- a/index.js
+++ b/index.js
@@ -55,18 +55,16 @@ module.exports = function (options) {
 				}
 			})
 			.then(() => {
-				const buildOptions = {
-					platforms: ['android']
-				};
+				const platformOptions = {};
 
 				if (release) {
 					// If the user wants to build for release, add the option
-					buildOptions.release = true;
+					platformOptions.release = true;
 				}
 
 				switch (buildMethod) {
 					case 'gradle':
-						buildOptions.gradle = true;
+						platformOptions.gradle = true;
 						break;
 					case 'ant':
 						throw new Error('Build method "ant" is no longer supported');
@@ -76,7 +74,7 @@ module.exports = function (options) {
 				}
 
 				// Build the platform
-				return cordova.build(buildOptions);
+				return cordova.build({platforms: ['android'], options: platformOptions});
 			})
 			.then(() => {
 				const apkOutputPath = 'build/outputs/apk';


### PR DESCRIPTION
* Switch to using an options object instead of providing "command-line-ish" options
  Since cordova-lib 5.4.0 the old approach is deprecated.
* Remove the "ant" build method and throw an error when that is requested
  cordova-android 7.0+ does no longer support "ant" for building
* Adapt to the change in how the 'gradle' option works in newer versions of cordova-android
  'gradle' used to select gradle instead of ant for building, but with cordova-android 7.0
  this breaks because that version prepares and assumes a 'android studio' build.

Fixes #30